### PR TITLE
agent-browser: fix dashboard pnpm-deps OOM on macOS CI

### DIFF
--- a/atelier.toml
+++ b/atelier.toml
@@ -15,15 +15,6 @@ include = [
   "checks.*.*",
 ]
 
-# agent-browser's dashboard pnpm-deps OOM-kill (exit 137) on the ~7 GB
-# macos-latest runner during the pnpm store write; it builds fine on real Macs
-# and on both Linux runners. Excluding only the aarch64-darwin CI build keeps
-# darwin support in the package while keeping CI green. Revisit once a binary
-# cache is configured (the deps can then be built once and substituted).
-exclude = [
-  "packages.aarch64-darwin.agent-browser",
-]
-
 # No binary cache configured yet: every run rebuilds and pushes nothing. List
 # your own cache endpoint(s) here once wired up to skip already-cached attrs.
 substituters = []

--- a/pkgs/agent-browser/default.nix
+++ b/pkgs/agent-browser/default.nix
@@ -49,6 +49,28 @@ let
       inherit version src pnpm;
       pnpmWorkspaces = [ "dashboard" ];
       fetcherVersion = 3;
+
+      # The dashboard deps fetch OOM-kills (SIGKILL, exit 137) at the end of
+      # `pnpm install` ("added 753, done") on the ~7 GB macos-latest CI runner
+      # where atelier builds aarch64-darwin. The memory is in pnpm's worker
+      # pool that writes the content-addressable store, so cap it to one worker
+      # (PNPM_MAX_WORKERS for pnpm 11; PNPM_WORKERS=999, read by older pnpm as
+      # "CPUs to leave idle", collapses the pool to one as a fallback) and cap
+      # node's heap to force earlier GC. NODE_NO_WARNINGS drops the ~61k libuv
+      # "unmanaged fd" warnings the store write emits. child/network-concurrency
+      # bound the resolution phase. All are scheduling/memory/log knobs, so they
+      # change how the store is written, not its contents: the fixed-output
+      # `hash` below is unchanged (verified via `nix build --rebuild`) and Linux
+      # consumers are unaffected.
+      PNPM_MAX_WORKERS = "1";
+      PNPM_WORKERS = "999";
+      NODE_OPTIONS = "--max-old-space-size=2048";
+      NODE_NO_WARNINGS = "1";
+      prePnpmInstall = ''
+        pnpm config set child-concurrency 1
+        pnpm config set network-concurrency 1
+      '';
+
       hash = "sha256-e7KlsuqS1YRcdQbKJwH9Dd6N28tYM3nPinJB5ZzSbp4=";
     };
 


### PR DESCRIPTION
## Summary

The migration PR (#288) excluded `packages.aarch64-darwin.agent-browser` from atelier CI because its dashboard pnpm-deps fetch **OOM-killed** (SIGKILL, exit 137) at the end of `pnpm install` on the ~7 GB `macos-latest` runner. This PR replaces that workaround with a **real fix** and restores the darwin build.

## Root cause

From the failed run's build.log artifact:
```
agent-browser-dashboard-pnpm-deps> Progress: resolved 753, ... added 753, done
...setup: line 1826: 4206 Killed: 9   pnpm install --force --ignore-scripts ...
error: builder failed with exit code 137.
```
No "JavaScript heap out of memory" message → the OS killed pnpm under total memory pressure during the parallel store-write finalization, not a V8 heap cap. Darwin-specific; the package builds fine on `x86_64-linux` and `aarch64-linux`.

## Fix

Serialize pnpm's extraction/linking via `prePnpmInstall`:
```nix
prePnpmInstall = ''
  pnpm config set child-concurrency 1
  pnpm config set network-concurrency 1
'';
```

**Hash-safe (verified):** concurrency only changes *how* the pnpm store is written, not *what* it contains. The `fetchPnpmDeps` output is a fixed-output derivation hashed by store contents (lockfile-determined), so the declared `hash` is unchanged:
- `nix build --rebuild` of the pnpmDeps FOD passes (`checking outputs ...` clean) — output reproduces the declared hash `sha256-e7Klsuq…`.
- Full `nix build .#agent-browser` on x86_64-linux passes.
- Build log confirms `"childConcurrency": 1, "networkConcurrency": 1` registered.

Linux consumers are completely unaffected (no rebuild, no hash bump).

Also drops the now-redundant `aarch64-darwin.agent-browser` exclude from `atelier.toml`, so atelier discovery includes it on macOS again (verified: it's back as a build cell, no longer "Excluded by rule").

## Caveat

The macOS OOM cannot be reproduced off a `macos-latest` runner, so the definitive validation is this PR's CI run. Watch the `Build / packages.aarch64-darwin.agent-browser` cell: it should now **build green** instead of being skipped. If the throttle proves insufficient, the fallback is re-adding the exclude.