### PR TITLE
ci(evergreen): add OpenCode packaging review after bumps

### DIFF
--- a/.github/evergreen-review-prompt.md
+++ b/.github/evergreen-review-prompt.md
@@ -1,0 +1,89 @@
+# Evergreen package review
+
+You are reviewing a single Nix package in this repository (a NUR-style package
+set) immediately after an automated version bump. The package attribute name and
+the initial `nix build` outcome are provided in the invocation message.
+
+Your goal is a package definition that **builds**, **matches upstream's
+dependencies**, and **follows nixpkgs best practices** — not merely a green
+build. A bump that builds can still be wrong (stale dependency set, hacks); a
+bump that fails to build may need more than a hash refresh.
+
+## Scope
+
+- Edit **only** files under `pkgs/<package>/`. Never touch other packages, the
+  flake, the workflows, or `tasks/`.
+- Run all verification from the repository root with `nix build .#<package>`.
+
+## What to check, in order
+
+1. **Read the bump diff first.** Run `git show HEAD -- pkgs/<package>/` to see
+   exactly what the update changed (version, rev, hashes). Understand the
+   package's builder before changing anything.
+
+1. **Reconcile dependencies with upstream.** This is the most important and most
+   commonly missed step. A version bump frequently adds, removes, or re-pins
+   upstream dependencies that the Nix expression does not track. Fetch the
+   upstream manifest for the *new* version and make the Nix dependency set match
+   it:
+
+   - Rust → `Cargo.toml` / `Cargo.lock` vs `cargoHash` (and any
+     `cargoLock.outputHashes` for git deps).
+   - npm → `package.json` / `package-lock.json` vs `npmDepsHash`.
+   - pnpm → `package.json` / `pnpm-lock.yaml` vs `fetchPnpmDeps` `hash`.
+   - Python → `pyproject.toml` / `setup.py` / `requirements*.txt` vs the
+     `python3.withPackages` list (or `dependencies` / `propagatedBuildInputs`).
+   - Go → `go.mod` / `go.sum` vs `vendorHash`.
+   - .NET → the `*.csproj` / `*.sln` `PackageReference`s vs `deps.json`.
+   - C/C++/meson/cmake → upstream build files vs `buildInputs` /
+     `nativeBuildInputs`.
+
+   Add missing dependencies and remove ones upstream dropped. If a required
+   dependency is **not packaged in nixpkgs**, add it with a clear `# TODO:`
+   comment naming the dependency and why it is absent, rather than silently
+   dropping or faking it.
+
+1. **Recompute fixed-output hashes the canonical way.** When a lockfile or source
+   changed, set the relevant hash to `lib.fakeHash` (or `""`), run the build, and
+   copy the real SRI hash from the `got:` line of the mismatch error back into the
+   file. Applies to `cargoHash`, `npmDepsHash`, pnpm `hash`, `vendorHash`, and
+   per-platform `src` hashes. Tools available on PATH: `nix-prefetch-git`,
+   `prefetch-npm-deps`, `nurl`. For .NET, regenerate `deps.json` via
+   `nix-build .#<package>.fetch-deps` (or the package's `fetch-deps` attribute).
+   Never hand-edit a hash to a guessed value.
+
+1. **Verify.** Run `nix build .#<package>` and iterate until it succeeds (when you
+   are in fix mode) or confirm it still succeeds (when you are in review mode).
+
+## Best practices (hard rules)
+
+- Follow nixpkgs conventions. Prefer the upstream-faithful dependency set and the
+  standard builder mechanisms.
+- **Do not hack around problems.** No `--impure`, no disabling the sandbox, no
+  guessed hashes, no deleting or disabling tests to force a pass, no inline
+  shell that papers over a real breakage. `doCheck = false` is acceptable only
+  for a genuine sandbox limitation (network/hardware/live-service tests) and must
+  carry a comment explaining why; prefer skipping individual tests
+  (`checkFlags` / `disabledTests`) over disabling the whole suite.
+- Use `postPatch` / `substituteInPlace` only for small, legitimate adaptations
+  (hardcoded paths, sandbox-incompatible fetches). For anything structural,
+  prefer a real `patches = [ ... ]` file.
+- Keep `meta` correct: `license` mapped to the right `lib.licenses.*`, accurate
+  `platforms`, and existing `maintainers` preserved.
+- Match the existing code style of the file and the rest of `pkgs/`.
+
+## When to STOP and fail
+
+If you hit a genuine blocker, **do not** force a green build by weakening the
+package. Instead, make no further edits, print a clear explanation prefixed with
+`BLOCKED:` describing the blocker and what a human needs to do, and exit with a
+non-zero status. Blockers include:
+
+- A required dependency is missing from nixpkgs and packaging it is non-trivial.
+- The build genuinely needs network access at build time that cannot be vendored.
+- Upstream changed to an incompatible or unsupported build system.
+- The upstream tag/source was retracted, moved, or no longer matches.
+
+A red PR with a precise `BLOCKED:` explanation is the correct outcome in these
+cases — it is strictly better than a build that only passes because it was
+hacked.

--- a/.github/opencode.json
+++ b/.github/opencode.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "share": "disabled",
+  "autoupdate": false,
+  "small_model": "dendro/gpt-5.4-mini",
+  "model": "dendro/gpt-5.5",
+  "provider": {
+    "dendro": {
+      "npm": "@ai-sdk/openai",
+      "name": "Dendro (LiteLLM)",
+      "options": {
+        "baseURL": "https://dendro.codgician.me/v1",
+        "apiKey": "{env:DENDRO_API_KEY}"
+      },
+      "models": {
+        "gpt-5.5": {
+          "name": "gpt-5.5",
+          "options": {
+            "reasoningEffort": "high"
+          }
+        },
+        "gpt-5.4-mini": {
+          "name": "gpt-5.4-mini"
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/evergreen.yml
+++ b/.github/workflows/evergreen.yml
@@ -91,6 +91,70 @@ jobs:
             echo "update.nix execution failed"
             exit 1
           fi
+      - name: Check build
+        id: check_build
+        if: steps.run_update_script.outputs.pr_title != ''
+        run: |
+          # Capture the result instead of hard-failing: the OpenCode review step
+          # runs on both outcomes (reviewer when it passed, fixer when it failed).
+          if nix build .#${{ matrix.package }} 2>&1 | tee /tmp/build.log; then
+            echo "build_ok=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "build_ok=0" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Review and fix bump with OpenCode
+        id: opencode_review
+        # Runs after every successful bump. The agent reconciles the package's
+        # dependencies with upstream and enforces nixpkgs best practices: as a
+        # reviewer when the build passed, as a fixer when it failed. It runs
+        # inside the flake dev shell (`nix develop`) so every update-script tool
+        # (nix-prefetch-git, prefetch-npm-deps, nurl, ...) is on PATH for it to
+        # recompute hashes and re-run `nix build` while iterating.
+        if: steps.run_update_script.outputs.pr_title != ''
+        timeout-minutes: 30
+        env:
+          DENDRO_API_KEY: ${{ secrets.DENDRO_API_KEY }}
+          OPENCODE_CONFIG: ${{ github.workspace }}/.github/opencode.json
+          OPENCODE_DISABLE_CLAUDE_CODE: '1'
+          OPENCODE_DISABLE_AUTOUPDATE: '1'
+        run: |
+          if [ -z "$DENDRO_API_KEY" ]; then
+            echo "DENDRO_API_KEY secret is not set; skipping review." >&2
+            exit 0
+          fi
+
+          if [ "${{ steps.check_build.outputs.build_ok }}" = "1" ]; then
+            STATE="The initial 'nix build .#${{ matrix.package }}' SUCCEEDED. Act as a reviewer: confirm the dependencies still match upstream for the new version and that nixpkgs best practices are followed, and fix anything that is wrong. If nothing needs changing, make no edits."
+          else
+            STATE="The initial 'nix build .#${{ matrix.package }}' FAILED; the log is at /tmp/build.log. Act as a fixer: diagnose and repair the failure (commonly a stale dependency hash or a dependency set that drifted from upstream)."
+          fi
+
+          MSG="Read the file .github/evergreen-review-prompt.md in this repository; it is your full instructions. Then review the package '${{ matrix.package }}' accordingly. ${STATE}"
+
+          nix develop ".#" -c opencode run \
+            --pure \
+            --dangerously-skip-permissions \
+            --model dendro/gpt-5.5 \
+            "$MSG"
+      - name: Verify and commit OpenCode changes
+        id: verify_fix
+        if: steps.run_update_script.outputs.pr_title != ''
+        run: |
+          # Only keep the agent's edits if they are real and the package still
+          # builds. This is the hard gate against a hacked or broken result.
+          if [ -z "$(git status --porcelain "pkgs/${{ matrix.package }}")" ]; then
+            echo "OpenCode made no changes."
+            exit 0
+          fi
+
+          if nix build .#${{ matrix.package }}; then
+            git add "pkgs/${{ matrix.package }}"
+            git commit -m "${{ matrix.package }}: reconcile packaging after bump (opencode)"
+            echo "Committed OpenCode changes."
+          else
+            echo "OpenCode changes do not build; discarding so the PR reflects only the bump." >&2
+            git checkout -- "pkgs/${{ matrix.package }}" 2>/dev/null || true
+          fi
       - name: Create pull request
         uses: peter-evans/create-pull-request@v8
         if: steps.run_update_script.outputs.pr_title != ''
@@ -103,7 +167,3 @@ jobs:
           body: "This pull request is created automatically by the evergreen action which runs periodically to bump packages."
           labels: "bot"
           reviewers: "codgician"
-      - name: Check build
-        if: steps.run_update_script.outputs.pr_title != ''
-        run: |-
-          nix build .#${{ matrix.package }}

--- a/flake.nix
+++ b/flake.nix
@@ -48,11 +48,42 @@
         }
       );
 
-      devShell = forAllSystems (
+      # Tooling shell for running package `updateScript`s and the OpenCode
+      # build-failure auto-fix agent used by the evergreen workflow. Anything
+      # the agent might shell out to while diagnosing a failed bump lives here,
+      # so `nix develop -c opencode ...` (and humans) get them all on PATH.
+      devShells = forAllSystems (
         system:
-        with nixpkgs.legacyPackages.${system};
-        mkShell {
-          buildInputs = [ ];
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              # Core
+              git
+              cacert
+              coreutils
+              # Update-script utilities (union of all pkgs/*/update.sh deps)
+              curl
+              jq
+              gnused
+              gnugrep
+              nodejs
+              # Nix source/hash prefetchers for recomputing fixed-output hashes
+              nix-update
+              nix-prefetch-git
+              prefetch-npm-deps
+              nurl
+              # OpenCode agent (evergreen build-failure auto-fix)
+              opencode
+            ];
+
+            # Make sure update scripts can find the repository root.
+            shellHook = ''
+              export NIX_PATH="nixpkgs=${pkgs.path}"
+            '';
+          };
         }
       );
 


### PR DESCRIPTION
## What

After each automated package bump in the `evergreen` workflow, run OpenCode (gpt-5.5 via the self-hosted Dendro LiteLLM endpoint) to reconcile the package against upstream and enforce nixpkgs best practices:

- **build passed → reviewer mode**: verify the dependency set still matches upstream for the new version and that nixpkgs conventions hold; fix anything wrong, otherwise make no edits.
- **build failed → fixer mode**: diagnose and repair (commonly a stale dependency hash or a dependency set that drifted from upstream).

Agent edits are kept **only if they still build** (hard `nix build` gate); otherwise they are discarded so the PR reflects only the bump. On a genuine blocker the agent emits a `BLOCKED:` explanation and the PR is left red for human review rather than hacked green.

## Changes

- **`flake.nix`**: replace the placeholder `devShell` with `devShells.default` carrying the union of update-script tools + `opencode`, so the agent runs inside `nix develop` with everything on PATH (hash prefetchers, node, etc.).
- **`.github/opencode.json`**: Dendro provider via `@ai-sdk/openai` (Responses API), `gpt-5.5` with `reasoningEffort: high`, `gpt-5.4-mini` small_model, API key via `{env:DENDRO_API_KEY}`.
- **`.github/evergreen-review-prompt.md`**: the packaging review policy — upstream-manifest reconciliation across all repo ecosystems (Rust/npm/pnpm/Python/Go/.NET/C++), the canonical fake-hash recompute workflow, nixpkgs DO/DON'T rules, and the `BLOCKED:` fail contract.
- **`.github/workflows/evergreen.yml`**: capture the post-bump build result, run the dual-mode OpenCode step (gated on a successful bump), then a verify-and-commit gate before the PR is created.

## Notes / required setup

- Requires a repo secret named **`DENDRO_API_KEY`**. If unset, the review step is skipped (no-op), so the workflow stays green.
- Reviewer mode may auto-commit packaging corrections beyond the raw bump (e.g. adding a missing Python dependency). All such commits are build-verified and land on the `bot/<package>` branch for review.

## Validation

- `actionlint`, `yamlfmt`, `mdformat`, and `jq` all pass on the changed files.
- `devShells.default` builds; all tools resolve on PATH.
- End-to-end verified against the live Dendro endpoint: provider auth, gpt-5.5 high-reasoning, autonomous file edits, and the agent self-reading the policy file.