### PR TITLE
ci: support service-aware package validation

### DIFF
--- a/.github/evergreen-review-prompt.md
+++ b/.github/evergreen-review-prompt.md
@@ -10,7 +10,7 @@ If the updater succeeded, review its existing bump and repair only real defects.
 
 - The version is the latest stable, non-draft, non-prerelease upstream release.
 - Source revisions, real hashes, dependencies, lockfiles, patches, build flags, metadata, provenance, platforms, and `mainProgram` agree with authoritative upstream evidence.
-- The package builds reproducibly without build-time network access and its focused offline smoke check passes.
+- The package builds reproducibly without build-time network access and its focused offline smoke check passes. A long-running service must provide `passthru.tests.smoke` that starts it on loopback, probes readiness, and stops it cleanly instead of relying on `--help`.
 - Ensure `passthru.updateScript` updates every related version and hash and is idempotent for the same release.
 - Never replace a sufficient `nix-update-script` or `gitUpdater` with a custom updater. Use custom code only when the generic updaters cannot satisfy that contract, and document the concrete limitation.
 - The final diff contains only the complete update under `pkgs/<package>/`.

--- a/.github/new-package-prompt.md
+++ b/.github/new-package-prompt.md
@@ -10,7 +10,7 @@ Create `pkgs/<package>/` for the request in `.ai-state/request.json`. Package th
 - Prefer buildable source. Use an upstream binary only when no practical source build exists, and declare accurate `meta.sourceProvenance`.
 - Use immutable sources and real hashes. Match upstream manifests, lockfiles, dependencies, and build flags; the Nix build must not fetch from the network.
 - Provide accurate `meta`: description, homepage, changelog when available, license, provenance, supported platforms, `maintainers = with lib.maintainers; [ codgician ];`, and `mainProgram` when applicable. `x86_64-linux` must be supported.
-- Add a small deterministic offline smoke check.
+- Add `passthru.tests.smoke` as a small deterministic offline check. For a CLI, exercise version or help output; for a long-running service, start it on loopback, probe readiness, and stop it cleanly.
 - Add an idempotent `passthru.updateScript` that discovers stable releases and updates every related version and hash.
 - Prefer `nix-update-script`; use `gitUpdater` when only tag prefix or suffix handling is needed. Create a custom updater only after testing both and proving they cannot satisfy that contract, and document the concrete limitation in a comment.
 - Run the updater, build, and relevant smoke check. Finish with a package-only diff that passes those checks.

--- a/.github/scripts/run_smoke_test.sh
+++ b/.github/scripts/run_smoke_test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+set -euo pipefail
+
+package=${1:?package is required}
+output=${2:?output path is required}
+main_program=${3:-none}
+
+has_smoke=$(nix eval --json ".#$package" --apply 'p: p ? tests.smoke')
+case "$has_smoke" in
+  true)
+    exec nix build --no-link ".#$package.tests.smoke"
+    ;;
+  false) ;;
+  *)
+    echo "Could not determine whether $package provides tests.smoke" >&2
+    exit 1
+    ;;
+esac
+
+if [[ "$main_program" == "none" ]]; then
+  exit 0
+fi
+if [[ ! "$main_program" =~ ^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$ || "$main_program" == *..* ]]; then
+  echo "Invalid meta.mainProgram: $main_program" >&2
+  exit 2
+fi
+
+program="$output/bin/$main_program"
+resolved=$(readlink -f "$program")
+if [[ ! -x "$program" || "$resolved" != "$output/"* ]]; then
+  echo "meta.mainProgram is not a contained executable: $program" >&2
+  exit 1
+fi
+
+smoke_home=$(mktemp -d)
+trap 'rm -rf "$smoke_home"' EXIT
+(
+  cd "$smoke_home"
+  HOME="$smoke_home" XDG_DATA_HOME="$smoke_home/data" timeout 30 "$program" --help >/dev/null
+)

--- a/.github/scripts/validate_bump.sh
+++ b/.github/scripts/validate_bump.sh
@@ -24,21 +24,16 @@ if ! main_program=$(nix eval --raw ".#$package.meta.mainProgram" 2>/dev/null); t
     echo "Package removed its required meta.mainProgram: $baseline_main_program" >&2
     exit 1
   fi
-  exit 0
-fi
-if [[ ! "$main_program" =~ ^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$ || "$main_program" == *..* ]]; then
-  echo "Invalid meta.mainProgram: $main_program" >&2
-  exit 1
-fi
-if [[ "$baseline_main_program" != "none" && "$main_program" != "$baseline_main_program" ]]; then
-  echo "Package changed meta.mainProgram from $baseline_main_program to $main_program" >&2
-  exit 1
+  main_program=none
+else
+  if [[ ! "$main_program" =~ ^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$ || "$main_program" == *..* ]]; then
+    echo "Invalid meta.mainProgram: $main_program" >&2
+    exit 1
+  fi
+  if [[ "$baseline_main_program" != "none" && "$main_program" != "$baseline_main_program" ]]; then
+    echo "Package changed meta.mainProgram from $baseline_main_program to $main_program" >&2
+    exit 1
+  fi
 fi
 
-program="$output/bin/$main_program"
-resolved=$(readlink -f "$program")
-if [[ ! -x "$program" || "$resolved" != "$output/"* ]]; then
-  echo "meta.mainProgram is not a contained executable: $program" >&2
-  exit 1
-fi
-timeout 30 "$program" --help >/dev/null
+exec .github/scripts/run_smoke_test.sh "$package" "$output" "$main_program"

--- a/.github/scripts/validate_new_package.sh
+++ b/.github/scripts/validate_new_package.sh
@@ -41,6 +41,8 @@ if [[ "$main_program_json" != "null" ]]; then
     echo "Invalid meta.mainProgram: $main_program" >&2
     exit 2
   fi
+else
+  main_program=none
 fi
 
 nix eval --json .#lib.packagesWithUpdateScript \
@@ -52,12 +54,4 @@ if [[ "$output" == *$'\n'* ]]; then
   echo "Expected one primary output path for $package" >&2
   exit 1
 fi
-if [[ -n "${main_program:-}" ]]; then
-  program="$output/bin/$main_program"
-  resolved=$(readlink -f "$program")
-  if [[ ! -x "$program" || "$resolved" != "$output/"* ]]; then
-    echo "meta.mainProgram is not a contained executable: $program" >&2
-    exit 1
-  fi
-  timeout 30 "$program" --help >/dev/null
-fi
+.github/scripts/run_smoke_test.sh "$package" "$output" "$main_program"

--- a/.github/workflows/evergreen.yml
+++ b/.github/workflows/evergreen.yml
@@ -368,13 +368,21 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: Download verified result
+        id: verified
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: evergreen-verified-${{ matrix.package }}
           path: ${{ runner.temp }}/verified
       - name: Apply verified result
         id: result
+        env:
+          VERIFIED_DOWNLOAD: ${{ steps.verified.outcome }}
         run: |
+          if [[ "$VERIFIED_DOWNLOAD" != "success" ]]; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           state=$(cat "$RUNNER_TEMP/verified/state")
           if [[ "$state" == "up-to-date" ]]; then
             echo "publish=false" >> "$GITHUB_OUTPUT"
@@ -426,6 +434,7 @@ jobs:
             echo "origin_label=$origin_label"
           } >> "$GITHUB_OUTPUT"
       - name: Generate publisher token
+        if: steps.result.outputs.publish == 'true'
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:

--- a/pkgs/aiursoft-tracer/default.nix
+++ b/pkgs/aiursoft-tracer/default.nix
@@ -3,7 +3,10 @@
   buildDotnetModule,
   dotnetCorePackages,
   buildNpmPackage,
+  curl,
   fetchFromGitHub,
+  procps,
+  runCommand,
   ...
 }:
 
@@ -12,11 +15,11 @@ let
   src = fetchFromGitHub {
     owner = "AiursoftWeb";
     repo = "Tracer";
-    rev = "c9765478259ca2519c06c016a4d8a093b1c76f11";
-    hash = "sha256-cQyzznvJdeAFCoovFgkJv7RrAOBSrAO7t5c1FSp+6To=";
+    rev = "b04b7af5cb45ad8a707c1525e7b2b349e0d6f109";
+    hash = "sha256-uflAejOLtI5pB3w5CEVoJE/kbCXoZhf8pFla2iJNRys=";
   };
 
-  version = "0-unstable-2026-07-11";
+  version = "0-unstable-2026-07-14";
 
   wwwroot = buildNpmPackage {
     pname = "${pname}-wwwroot";
@@ -39,42 +42,85 @@ let
     '';
   };
 in
-buildDotnetModule {
-  inherit
-    pname
-    src
-    version
-    wwwroot
-    ;
+let
+  package = buildDotnetModule {
+    inherit
+      pname
+      src
+      version
+      wwwroot
+      ;
 
-  dotnet-sdk = dotnetCorePackages.sdk_10_0;
-  dotnet-runtime = dotnetCorePackages.aspnetcore_10_0;
-  nugetDeps = ./deps.json;
+    dotnet-sdk = dotnetCorePackages.sdk_10_0;
+    dotnet-runtime = dotnetCorePackages.aspnetcore_10_0;
+    nugetDeps = ./deps.json;
 
-  projectFile = "Aiursoft.Tracer.sln";
-  enableParallelBuilding = false;
+    projectFile = "Aiursoft.Tracer.sln";
+    enableParallelBuilding = false;
 
-  postFixup = ''
-    # Symlink wwwroot
-    rm -rf $out/lib/${pname}/wwwroot
-    mkdir -p $out/assets
-    ln -s ${wwwroot} $out/assets/wwwroot
+    postFixup = ''
+      # Keep upstream's configuration beside the executable and replace only the
+      # mutable paths at runtime.
+      rm -rf $out/lib/${pname}/wwwroot
+      ln -s ${wwwroot} $out/lib/${pname}/wwwroot
 
-    # Patch working directory
-    dir=$out/assets
-    sedexpr='s/\(exec.*Aiursoft\.Tracer.*\)/(cd '
-    sedexpr+=''${dir//\//\\/}
-    sedexpr+=' \&\& \1)/g'
-    sed -i -e "$sedexpr" $out/bin/Aiursoft.Tracer
-  '';
+      # Run from the published application directory so appsettings.json is
+      # discovered, while persisting mutable data outside the Nix store.
+      dir=$out/lib/${pname}
+      sedexpr='s|\(exec.*Aiursoft\.Tracer.*\)|(cd '
+      sedexpr+="$dir"
+      sedexpr+=' \&\& dataDir="''${XDG_DATA_HOME:-$HOME/.local/share}/aiursoft-tracer" \&\& mkdir -p "$dataDir" \&\& ConnectionStrings__DefaultConnection="''${ConnectionStrings__DefaultConnection:-Data Source=$dataDir/app.db;Cache=Shared}" Storage__Path="''${Storage__Path:-$dataDir/data}" \1)|g'
+      sed -i -e "$sedexpr" $out/bin/Aiursoft.Tracer
+    '';
 
-  passthru.updateScript = ./update.sh;
+    passthru = {
+      updateScript = ./update.sh;
+      tests.smoke =
+        runCommand "${pname}-smoke"
+          {
+            nativeBuildInputs = [
+              curl
+              procps
+            ];
+          }
+          ''
+            export HOME="$TMPDIR/home"
+            export XDG_DATA_HOME="$TMPDIR/data"
+            export ASPNETCORE_URLS=http://127.0.0.1:18080
+            mkdir -p "$HOME" "$XDG_DATA_HOME"
 
-  meta = with lib; {
-    homepage = "https://tracer.aiursoft.com";
-    description = "Tracer is a simple network speed test app.";
-    license = licenses.mit;
-    platforms = platforms.linux;
-    mainProgram = "Aiursoft.Tracer";
+            ${lib.getExe package} --urls "$ASPNETCORE_URLS" > "$TMPDIR/server.log" 2>&1 &
+            server_pid=$!
+            cleanup() {
+              pkill -TERM -P "$server_pid" 2>/dev/null || true
+              kill "$server_pid" 2>/dev/null || true
+              wait "$server_pid" 2>/dev/null || true
+            }
+            trap cleanup EXIT
+
+            for _ in $(seq 1 30); do
+              if curl --fail --silent "$ASPNETCORE_URLS"/ > /dev/null; then
+                touch "$out"
+                exit 0
+              fi
+              if ! kill -0 "$server_pid" 2>/dev/null; then
+                cat "$TMPDIR/server.log" >&2
+                exit 1
+              fi
+              sleep 1
+            done
+            cat "$TMPDIR/server.log" >&2
+            exit 1
+          '';
+    };
+
+    meta = with lib; {
+      homepage = "https://tracer.aiursoft.com";
+      description = "Tracer is a simple network speed test app.";
+      license = licenses.mit;
+      platforms = platforms.linux;
+      mainProgram = "Aiursoft.Tracer";
+    };
   };
-}
+in
+package

--- a/pkgs/aiursoft-tracer/deps.json
+++ b/pkgs/aiursoft-tracer/deps.json
@@ -236,8 +236,8 @@
   },
   {
     "pname": "Microsoft.CodeCoverage",
-    "version": "18.7.0",
-    "hash": "sha256-QonDzKnOwcYkkVP0T3PT9/QySgUILc/L/bcp6+l+tA8="
+    "version": "18.8.0",
+    "hash": "sha256-sYJuztIr/rB8GdRlaxBezEpT/QXGZNcy1tkRdM2qlfg="
   },
   {
     "pname": "Microsoft.Data.Sqlite.Core",
@@ -506,33 +506,33 @@
   },
   {
     "pname": "Microsoft.NET.Test.Sdk",
-    "version": "18.7.0",
-    "hash": "sha256-m2cPE5Y7lQz1nmyjlaf4bf9LpABQa24wiga7HPN4LgQ="
+    "version": "18.8.0",
+    "hash": "sha256-V3woExKbCVIOcq3CIpyeu+WYHYAt4Ds4+z8fYuRJ9Y4="
   },
   {
     "pname": "Microsoft.Testing.Extensions.Telemetry",
-    "version": "2.3.1",
-    "hash": "sha256-bsiydeM5M62UxpMWErLK/7CNMGgSfrJLPf6kWFXKow8="
+    "version": "2.3.2",
+    "hash": "sha256-3TancCfYy7OW9IU6q+zQv/ETlbBbcjxADrWVRQITytc="
   },
   {
     "pname": "Microsoft.Testing.Extensions.TrxReport.Abstractions",
-    "version": "2.3.1",
-    "hash": "sha256-hexa+LrTEkNyiDsgc5dstOzJZ0HIsBfuPzzWkWVQ1AY="
+    "version": "2.3.2",
+    "hash": "sha256-MohDLqtLk1K93p1TnvYlaBNetpGoTZSep3xVQho3zb0="
   },
   {
     "pname": "Microsoft.Testing.Extensions.VSTestBridge",
-    "version": "2.3.1",
-    "hash": "sha256-oXYlrPhXuF5v0PxPYVjTAye8tLHmoOi+XHdmjzmwduk="
+    "version": "2.3.2",
+    "hash": "sha256-9W4FmGvIfuwHQr3AFrCZ/uLhtJws5erQccw7ydT5yBU="
   },
   {
     "pname": "Microsoft.Testing.Platform",
-    "version": "2.3.1",
-    "hash": "sha256-7L25Cf8WfgMMIswe2WMHSAfbqs0rjGir8sjVpL/jQ0U="
+    "version": "2.3.2",
+    "hash": "sha256-kGOyHXenLNMpWyVTDWDh6/hP3qFtnHI5qIaet1udKWM="
   },
   {
     "pname": "Microsoft.Testing.Platform.MSBuild",
-    "version": "2.3.1",
-    "hash": "sha256-xyKJOd5DfQoKQoMZEthyeOEL9oX6SGlNMkh2F4VAa50="
+    "version": "2.3.2",
+    "hash": "sha256-u0jsv5BU7gSBZlHoy94WlqM0QCJCFbEW1g19RxKn17Q="
   },
   {
     "pname": "Microsoft.TestPlatform.ObjectModel",
@@ -541,13 +541,13 @@
   },
   {
     "pname": "Microsoft.TestPlatform.ObjectModel",
-    "version": "18.7.0",
-    "hash": "sha256-OJYJt3EhJ60HobDzET31dESe29BtqDd35Xjt8/2BQCQ="
+    "version": "18.8.0",
+    "hash": "sha256-sdgyIQuubONxeXIJZSBB7uVAaJrZmHcOCfQowtUmKxk="
   },
   {
     "pname": "Microsoft.TestPlatform.TestHost",
-    "version": "18.7.0",
-    "hash": "sha256-i5XpKR5rgazQ5ZLPGE/F71h0Sp6Ko/ff1NzLo+lsE5M="
+    "version": "18.8.0",
+    "hash": "sha256-giN2FRgDGdKfK8dtgQ0/9wc6aRuSwDmFK1L5wsq9yF0="
   },
   {
     "pname": "Microsoft.VisualStudio.SolutionPersistence",
@@ -561,18 +561,18 @@
   },
   {
     "pname": "MSTest.Analyzers",
-    "version": "4.3.0",
-    "hash": "sha256-aG+dYk1bdQTwQ3QHO4XBIJbjOdsffVcWpWhHAOvNB/Y="
+    "version": "4.3.2",
+    "hash": "sha256-mzMMs8H6u2pRnOb6UjA1pwSOKsULx2v18Stvp/cvxj0="
   },
   {
     "pname": "MSTest.TestAdapter",
-    "version": "4.3.0",
-    "hash": "sha256-3Pte6D3+PQoi6xGLZPHvJBGGs2G02tMA1AxBzTw9dh8="
+    "version": "4.3.2",
+    "hash": "sha256-qiXoMftAKNEtN2LFwMd2e8EkBn03RfIk15CljjOuU0A="
   },
   {
     "pname": "MSTest.TestFramework",
-    "version": "4.3.0",
-    "hash": "sha256-AdofL+X0tFujJz39zkiCMTx5Rj8d4ZKGNWfiH8IkDS4="
+    "version": "4.3.2",
+    "hash": "sha256-BQUOSbJd2LE5C4C5yx7MTozHaWxpo5R6mPC6EdzVHVk="
   },
   {
     "pname": "MySqlConnector",

--- a/pkgs/aiursoft-tracer/update.sh
+++ b/pkgs/aiursoft-tracer/update.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -i bash -p git curl jq nodejs prefetch-npm-deps nix-prefetch-git
 
+# Generic git updaters cannot regenerate this package's npm dependency hash and
+# NuGet dependency hashes, so this script updates all related sources together.
+set -euo pipefail
+
 nur="$(git rev-parse --show-toplevel)"
 path="$nur/pkgs/aiursoft-tracer/default.nix"
-prefetch=$(nix-prefetch-git --url https://github.com/AiursoftWeb/Tracer --no-deepClone)
+prefetch=$(env -u DENDRO_API_KEY nix-prefetch-git --url https://github.com/AiursoftWeb/Tracer --no-deepClone)
 
 new_rev=$(echo "$prefetch" | jq -r '.rev')
 new_version="0-unstable-"$(echo "$prefetch" | jq -r '.date' | sed 's/T.*//')
-old_rev="$(sed -nE 's/\s*rev = "(.*)".*/\1/p' $path)"
-old_version="$(sed -nE 's/\s*version = "(.*)".*/\1/p' $path)"
+old_rev="$(sed -nE 's/\s*rev = "(.*)".*/\1/p' "$path")"
+old_version="$(sed -nE 's/\s*version = "(.*)".*/\1/p' "$path")"
 
 if [[ "$new_rev" == "$old_rev" ]]; then
     echo "Current revision $old_rev is up-to-date."
@@ -16,23 +20,23 @@ if [[ "$new_rev" == "$old_rev" ]]; then
 fi
 
 # Update the revision
-hash=$(echo $prefetch | jq -r '.hash')
+hash=$(echo "$prefetch" | jq -r '.hash')
 sed -i -e "s,rev = \"$old_rev\",rev = \"$new_rev\"," \
     -e "s,version = \"$old_version\",version = \"$new_version\"," \
     -e "s,hash = \"sha256-.*\",hash = \"$hash\"," "$path" 
 
 # Fetch npm deps
 tmpdir=$(mktemp -d)
-curl -O --output-dir $tmpdir "https://raw.githubusercontent.com/AiursoftWeb/Tracer/$new_rev/src/Aiursoft.Tracer/wwwroot/package-lock.json"
-curl -O --output-dir $tmpdir "https://raw.githubusercontent.com/AiursoftWeb/Tracer/$new_rev/src/Aiursoft.Tracer/wwwroot/package.json"
-pushd $tmpdir
+trap 'rm -rf "$tmpdir"' EXIT
+curl --fail --silent --show-error -O --output-dir "$tmpdir" "https://raw.githubusercontent.com/AiursoftWeb/Tracer/$new_rev/src/Aiursoft.Tracer/wwwroot/package-lock.json"
+curl --fail --silent --show-error -O --output-dir "$tmpdir" "https://raw.githubusercontent.com/AiursoftWeb/Tracer/$new_rev/src/Aiursoft.Tracer/wwwroot/package.json"
+pushd "$tmpdir"
 # Keep in sync with the postPatch rewrite in default.nix: Aiursoft's private
 # npm registry is unreliable, so deps are fetched from the official registry.
 sed -i 's#https://npm.aiursoft.com/#https://registry.npmjs.org/#g' package-lock.json
 npm_hash=$(prefetch-npm-deps package-lock.json)
-sed -i 's#npmDepsHash = "[^"]*"#npmDepsHash = "'"$npm_hash"'"#' $path
+sed -i 's#npmDepsHash = "[^"]*"#npmDepsHash = "'"$npm_hash"'"#' "$path"
 popd
-rm -rf $tmpdir
 
 # Update nuget deps
-eval "$(nix-build . -A aiursoft-tracer.fetch-deps --no-out-link)"
+eval "$(env -u DENDRO_API_KEY nix-build . -A aiursoft-tracer.fetch-deps --no-out-link)"


### PR DESCRIPTION
## Problem

Evergreen treated every `meta.mainProgram` as a terminating CLI and ran `--help` under a 30-second timeout. `Aiursoft.Tracer` is a long-running ASP.NET service: the candidate started successfully on loopback, then validation returned timeout status 124. The publisher subsequently failed again because the missing verified artifact was treated as a second error.

## Fix

- Prefer package-provided `tests.smoke`; retain the generic `--help` fallback for CLI packages.
- Add a deterministic loopback readiness smoke test for `aiursoft-tracer` and preserve its writable data under XDG data paths.
- Update `aiursoft-tracer` to the current 2026-07-14 upstream revision with regenerated npm/NuGet hashes.
- Treat a missing verified artifact as a blocked validation result instead of a cascading publisher failure.
- Teach the AI prompts to add service-aware `passthru.tests.smoke` checks.

## Verification

- Exact `validate_candidate.sh` flow passed for `aiursoft-tracer` (`0-unstable-2026-07-11` → `0-unstable-2026-07-14`).
- Updater is idempotent on the updated package.
- `nix build --no-link .#aiursoft-tracer.tests.smoke` passed.
- CLI fallback passed for `oh-my-pi`.
- New-package validator passed for `oh-my-pi`.
- `actionlint`, `zizmor`, ShellCheck, and formatting checks passed.