### PR TITLE
ci: update bot branches despite unknown mergeability

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,15 +112,19 @@ jobs:
               core.notice("No deterministic bot PR is waiting for auto-merge");
               return;
             }
-            if (candidate.mergeable_state !== "behind") {
-              core.notice(`PR #${candidate.number} is ${candidate.mergeable_state}; no branch update needed`);
-              return;
+            try {
+              await github.rest.pulls.updateBranch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: candidate.number,
+                expected_head_sha: candidate.head.sha,
+              });
+              core.notice(`Updated PR #${candidate.number}; auto-merge will resume after required checks`);
+            } catch (error) {
+              const message = error.response?.data?.message || "";
+              if (error.status === 422 && /not behind/i.test(message)) {
+                core.notice(`PR #${candidate.number} is already up to date`);
+                return;
+              }
+              throw error;
             }
-
-            await github.rest.pulls.updateBranch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: candidate.number,
-              expected_head_sha: candidate.head.sha,
-            });
-            core.notice(`Updated PR #${candidate.number}; auto-merge will resume after required checks`);


### PR DESCRIPTION
The first deterministic queue run selected PR #354 while GitHub still reported `mergeable_state: unknown`, so it returned without updating the branch.

Call the update-branch endpoint directly and treat only the explicit “not behind” response as a no-op. This removes the asynchronous mergeability race while still surfacing real conflicts and API failures.

Verified with `actionlint`, `zizmor`, and formatting checks.