### PR TITLE
intune-portal: init at 1.2605.16-resolute

### DIFF
--- a/pkgs/intune-portal/default.nix
+++ b/pkgs/intune-portal/default.nix
@@ -1,0 +1,123 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  dpkg,
+  libuuid,
+  libx11,
+  curlMinimal,
+  openssl_3,
+  libsecret,
+  webkitgtk_4_1,
+  libsoup_3,
+  gtk3,
+  atk,
+  pango,
+  glib,
+  sqlite,
+  zlib,
+  systemd,
+  pam,
+  p11-kit,
+  dbus,
+  nixosTests,
+}:
+let
+  curlMinimal_openssl_3 = curlMinimal.override {
+    openssl = openssl_3;
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "intune-portal";
+  version = "1.2605.16-resolute";
+  ubuntuVersion = "26.04";
+
+  src = fetchurl {
+    url = "https://packages.microsoft.com/ubuntu/${ubuntuVersion}/prod/pool/main/i/intune-portal/intune-portal_${version}_amd64.deb";
+    hash = "sha256-EWJutvcKnzDj4Y+3oHHryRRyMLkNkaRPuCLqO2gq/Xo=";
+  };
+
+  nativeBuildInputs = [ dpkg ];
+
+  buildPhase =
+    let
+      libPath = {
+        intune = lib.makeLibraryPath [
+          stdenv.cc.cc
+          libuuid
+          libx11
+          curlMinimal_openssl_3
+          openssl_3
+          libsecret
+          webkitgtk_4_1
+          libsoup_3
+          gtk3
+          atk
+          glib
+          pango
+          p11-kit
+          sqlite
+          zlib
+          systemd
+          dbus
+        ];
+        pam = lib.makeLibraryPath [ pam ];
+      };
+    in
+    ''
+      runHook preBuild
+
+      patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) --set-rpath ${libPath.intune} opt/microsoft/intune/bin/intune-portal
+      patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) --set-rpath ${libPath.intune} opt/microsoft/intune/bin/intune-agent
+      patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) --set-rpath ${libPath.intune} opt/microsoft/intune/bin/intune-daemon
+      patchelf --set-rpath ${libPath.pam} ./usr/lib/x86_64-linux-gnu/security/pam_intune.so
+
+      runHook postBuild
+    '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp -a opt/microsoft/intune/bin/* $out/bin/
+    cp -a usr/share $out
+    cp -a opt/microsoft/intune/share/* $out/share/
+    cp -a lib $out
+    mkdir -p $out/lib/security
+    cp -a ./usr/lib/x86_64-linux-gnu/security/pam_intune.so $out/lib/security/
+    cp -a usr/lib/tmpfiles.d $out/lib
+
+    substituteInPlace $out/share/applications/intune-portal.desktop \
+      --replace /opt/microsoft/intune/bin/intune-portal $out/bin/intune-portal
+
+    substituteInPlace $out/lib/systemd/user/intune-agent.service \
+      --replace \
+        ExecStart=/opt/microsoft/intune/bin/intune-agent \
+        ExecStart=$out/bin/intune-agent
+
+    substituteInPlace $out/lib/systemd/system/intune-daemon.service \
+      --replace \
+        ExecStart=/opt/microsoft/intune/bin/intune-daemon \
+        ExecStart=$out/bin/intune-daemon
+
+    runHook postInstall
+  '';
+
+  # Without this network requests fail
+  dontPatchELF = true;
+
+  passthru = {
+    updateScript = ./update.sh;
+    tests = { inherit (nixosTests) intune; };
+  };
+
+  meta = {
+    description = "Microsoft Intune Portal allows you to securely access corporate apps, data, and resources";
+    homepage = "https://www.microsoft.com/";
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ codgician ];
+    mainProgram = "intune-portal";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}

--- a/pkgs/intune-portal/update.sh
+++ b/pkgs/intune-portal/update.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl dpkg gnugrep gnused coreutils jq nix
+# shellcheck shell=bash
+
+set -euo pipefail
+
+nur="$(git rev-parse --show-toplevel)"
+path="$nur/pkgs/intune-portal/default.nix"
+repository_root="https://packages.microsoft.com/ubuntu"
+package_path="prod/pool/main/i/intune-portal"
+
+old_ubuntu_version=$(sed -nE 's/^[[:space:]]*ubuntuVersion = "([^"]+)";.*/\1/p' "$path")
+old_version=$(sed -nE 's/^[[:space:]]*version = "([^"]+)";.*/\1/p' "$path")
+
+# update-source-version cannot discover or update the Ubuntu repository version,
+# so inspect every published Ubuntu repository and update both fields together.
+mapfile -t ubuntu_versions < <(
+    curl -fsSL "$repository_root/" \
+        | sed -nE 's@.*href="([0-9]+\.[0-9]+)/".*@\1@p' \
+        | sort -Vr
+)
+
+new_ubuntu_version=""
+new_version=""
+new_upstream_version=""
+
+for ubuntu_version in "${ubuntu_versions[@]}"; do
+    if ! package_index=$(curl -fsSL "$repository_root/$ubuntu_version/$package_path/" 2>/dev/null); then
+        continue
+    fi
+
+    while IFS= read -r candidate; do
+        candidate_upstream_version="${candidate%%-*}"
+        if [[ -z "$new_version" ]] || dpkg --compare-versions "$candidate_upstream_version" gt "$new_upstream_version"; then
+            new_ubuntu_version="$ubuntu_version"
+            new_version="$candidate"
+            new_upstream_version="$candidate_upstream_version"
+        fi
+    done < <(
+        printf '%s\n' "$package_index" \
+            | sed -nE 's@.*href="intune-portal_([^"]+)_amd64\.deb".*@\1@p'
+    )
+done
+
+if [[ -z "$new_ubuntu_version" || -z "$new_version" ]]; then
+    echo "Error: Could not resolve an Intune Portal release" >&2
+    exit 1
+fi
+
+if [[ "$old_ubuntu_version" == "$new_ubuntu_version" && "$old_version" == "$new_version" ]]; then
+    echo "Current Ubuntu $old_ubuntu_version package $old_version is up-to-date"
+    exit 0
+fi
+
+url="$repository_root/$new_ubuntu_version/$package_path/intune-portal_${new_version}_amd64.deb"
+new_hash=$(nix store prefetch-file --json "$url" | jq -er .hash)
+
+echo "Updating intune-portal: Ubuntu $old_ubuntu_version/$old_version -> Ubuntu $new_ubuntu_version/$new_version"
+
+sed -i \
+    -e "s|ubuntuVersion = \"$old_ubuntu_version\";|ubuntuVersion = \"$new_ubuntu_version\";|" \
+    -e "s|version = \"$old_version\";|version = \"$new_version\";|" \
+    -e "s|hash = \"sha256-[^\"]*\";|hash = \"$new_hash\";|" \
+    "$path"
+
+echo "Updated intune-portal to Ubuntu $new_ubuntu_version package $new_version"


### PR DESCRIPTION
## Summary

- package Microsoft Intune Portal from the Ubuntu 26.04 Microsoft repository
- include upstream OpenSSL compatibility and localization fixes
- add an updater that tracks both Intune releases and Ubuntu repository bumps

## Verification

- `nix build path:.#intune-portal -L`
- `./result/bin/intune-portal --version`
- updater reports Ubuntu 26.04 / 1.2605.16-resolute is current
- ShellCheck passes for `pkgs/intune-portal/update.sh`