### PR TITLE
ci: update behind queue entries

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -90,18 +90,21 @@ jobs:
                 (check) => check?.status === "completed" && !successfulConclusions.has(check.conclusion),
               );
 
-              if (!pending && !failed && details.mergeable_state !== "behind") {
+              if (details.mergeable_state === "behind") {
+                (failed ? failedBehind : greenBehind).push({
+                  number: pull.number,
+                  headSha: details.head.sha,
+                });
+                continue;
+              }
+              if (pending) {
+                core.notice(`PR #${pull.number} is current; waiting for required checks`);
+                return;
+              }
+              if (!failed) {
                 core.notice(`PR #${pull.number} is current and green; waiting for auto-merge`);
                 return;
               }
-              if (details.mergeable_state !== "behind" || pending) {
-                continue;
-              }
-
-              (failed ? failedBehind : greenBehind).push({
-                number: pull.number,
-                headSha: details.head.sha,
-              });
             }
 
             const selected = greenBehind[0] || failedBehind[0];


### PR DESCRIPTION
## Summary

The live controller smoke test found that GitHub regenerates a behind PR's test-merge SHA before checks exist on it. Missing checks therefore incorrectly made every behind PR look pending.

- treat `mergeable_state == behind` as requiring an update even when the regenerated test-merge ref has no checks
- continue to wait for required checks on current branches
- continue to skip current failed branches so later entries advance

## Verification

- `nix develop .# -c actionlint .github/workflows/merge-queue.yml`
- `nix fmt -- --ci .github/workflows/merge-queue.yml`
- `nix develop .# -c zizmor .github/workflows/merge-queue.yml`