### PR TITLE
ci: detect outdated queue branches

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -36,6 +36,12 @@ jobs:
               direction: "asc",
               per_page: 100,
             });
+            const { data: baseBranch } = await github.rest.repos.getBranch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch: "main",
+            });
+            const baseSha = baseBranch.commit.sha;
 
             const greenBehind = [];
             const failedBehind = [];
@@ -59,6 +65,12 @@ jobs:
               if (!details.auto_merge || details.mergeable_state === "dirty") {
                 continue;
               }
+              const { data: comparison } = await github.rest.repos.compareCommitsWithBasehead({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                basehead: `${details.head.sha}...${baseSha}`,
+              });
+              const behind = comparison.ahead_by > 0;
 
               const reviews = await github.paginate(github.rest.pulls.listReviews, {
                 owner: context.repo.owner,
@@ -90,7 +102,7 @@ jobs:
                 (check) => check?.status === "completed" && !successfulConclusions.has(check.conclusion),
               );
 
-              if (details.mergeable_state === "behind") {
+              if (behind) {
                 (failed ? failedBehind : greenBehind).push({
                   number: pull.number,
                   headSha: details.head.sha,


### PR DESCRIPTION
## Summary

GitHub's pull REST payload can expose a stale `base.sha`, and `mergeable_state` may transiently be `unknown`. Detect outdated branches by comparing each PR head against the live `main` branch SHA instead.

## Verification

- `nix develop .# -c actionlint .github/workflows/merge-queue.yml`
- `nix fmt -- --ci .github/workflows/merge-queue.yml`
- `nix develop .# -c zizmor .github/workflows/merge-queue.yml`
- workflow-dispatch smoke run [#29651363742](https://github.com/codgician/nur-packages/actions/runs/29651363742) selected and updated PR #380