### PR TITLE
Package mdatp with a NixOS service module

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,3 +1,3 @@
 {
-  # my_module = ./my_module
+  mdatp = ./mdatp.nix;
 }

--- a/modules/mdatp.nix
+++ b/modules/mdatp.nix
@@ -1,0 +1,147 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.mdatp;
+  packageDefault = pkgs.callPackage ../pkgs/mdatp { nurTests = { }; };
+  prepare = pkgs.writeShellScript "mdatp-prepare" ''
+    set -euo pipefail
+
+    if [[ -r /proc/config.gz ]]; then
+      install -d -m 0755 /boot
+      ${pkgs.gzip}/bin/gzip -dc /proc/config.gz >"/boot/config-$(${pkgs.coreutils}/bin/uname -r)"
+    fi
+
+    ${lib.optionalString (cfg.onboardingPath != null) ''
+      install -m 0600 ${lib.escapeShellArg cfg.onboardingPath} \
+        /etc/opt/microsoft/mdatp/mdatp_onboard.json
+    ''}
+  '';
+in
+{
+  options.services.mdatp = {
+    enable = lib.mkEnableOption "Microsoft Defender for Endpoint";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = packageDefault;
+      defaultText = lib.literalExpression "pkgs.callPackage ./pkgs/mdatp { }";
+      description = "The mdatp package to use.";
+    };
+
+    onboardingPath = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "/run/secrets/mdatp_onboard.json";
+      description = ''
+        Runtime path to the Microsoft Defender onboarding JSON. The file is
+        copied into place when the service starts, so its contents are not
+        copied into the Nix store.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    users.groups.mdatp = { };
+    users.users.mdatp = {
+      description = "Microsoft Defender for Endpoint service user";
+      group = "mdatp";
+      isSystemUser = true;
+    };
+
+    systemd.tmpfiles.rules = [
+      "d /opt/microsoft 0755 root root -"
+      "L+ /opt/microsoft/mdatp - - - - ${cfg.package}"
+      "d /etc/opt/microsoft/mdatp 0755 root root -"
+      "d /etc/opt/microsoft/mdatp/managed 0755 root root -"
+      "d /var/opt/microsoft/mdatp 0755 root root -"
+      "d /var/log/microsoft/mdatp 0775 root mdatp -"
+    ];
+
+    systemd.services.mdatp = {
+      description = "Microsoft Defender for Endpoint";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      path = with pkgs; [
+        coreutils
+        findutils
+        gnugrep
+        gzip
+        iproute2
+        iptables
+        nftables
+        procps
+        systemd
+        util-linux
+      ];
+      environment = {
+        ENABLE_CRASHPAD = "1";
+        LD_AUDIT = "";
+        LD_LIBRARY_PATH = "${cfg.package}/lib";
+        LD_PRELOAD = "";
+        MALLOC_ARENA_MAX = "2";
+      };
+      serviceConfig = {
+        Type = "simple";
+        ExecStartPre = prepare;
+        ExecStart = "${cfg.package}/sbin/wdavdaemon";
+        WorkingDirectory = "${cfg.package}/sbin";
+        NotifyAccess = "main";
+        LimitNOFILE = 65536;
+        Restart = "always";
+        RestartSec = 5;
+        Delegate = true;
+      };
+      unitConfig = {
+        StartLimitIntervalSec = 120;
+        StartLimitBurst = 3;
+      };
+    };
+
+    systemd.sockets.mde_netfilter_v2 = {
+      description = "Microsoft Defender Netfilter Activation Socket";
+      wantedBy = [ "sockets.target" ];
+      socketConfig.ListenStream = "/run/mde_netfilter.sock";
+    };
+
+    systemd.services.mde_netfilter_v2 = {
+      description = "Microsoft Defender Netfilter Platform";
+      after = [
+        "network.target"
+        "local-fs.target"
+      ];
+      requires = [ "mde_netfilter_v2.socket" ];
+      wantedBy = [ "multi-user.target" ];
+      path = with pkgs; [
+        coreutils
+        iptables
+        nftables
+      ];
+      environment.LD_LIBRARY_PATH = "${cfg.package}/lib";
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${cfg.package}/sbin/mde_netfilter";
+        WorkingDirectory = "${cfg.package}/sbin";
+        NotifyAccess = "main";
+        LimitCORE = "infinity";
+        KillMode = "process";
+        Restart = "on-failure";
+        PrivateTmp = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+      };
+      unitConfig = {
+        StartLimitIntervalSec = 120;
+        StartLimitBurst = 3;
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ codgician ];
+}

--- a/pkgs/mdatp/default.nix
+++ b/pkgs/mdatp/default.nix
@@ -1,0 +1,151 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  dpkg,
+  makeWrapper,
+  runCommand,
+  nurTests,
+  systemd,
+  libselinux,
+  libcxx,
+  minizip-ng,
+  curl,
+  libseccomp,
+  libuuid,
+  openssl,
+  libcap,
+  pcre2,
+  acl,
+  zlib,
+  fuse,
+  sqlite,
+  glib,
+  libffi,
+  libmnl,
+  libnetfilter_queue,
+  libnfnetlink,
+  coreutils,
+  gnugrep,
+  gzip,
+}:
+
+let
+  pname = "mdatp";
+  version = "101.26052.0011";
+  ubuntuVersion = "26.04";
+  architectures = {
+    x86_64-linux = "amd64";
+    aarch64-linux = "arm64";
+  };
+  hashes = {
+    x86_64-linux = "sha256-Y1dlU2DS0F3OGzY9ytpYtfjfx3YbWghCyFMzlcgjP+Q=";
+    aarch64-linux = "sha256-Y2gW4ox+TC72T+3l37Mij4YT9bZdJPAKc+vdX2gThbw=";
+  };
+  system = stdenv.hostPlatform.system;
+  architecture = architectures.${system} or (throw "${pname}: unsupported system ${system}");
+  runtimeLibraryPath = lib.makeLibraryPath [
+    systemd
+    libselinux
+    libcxx
+    minizip-ng
+    curl
+    libseccomp
+    libuuid
+    openssl
+    stdenv.cc.cc.lib
+    libcap
+    pcre2
+    acl
+    zlib
+    fuse
+    sqlite
+    glib
+    libffi
+    libmnl
+    libnetfilter_queue
+    libnfnetlink
+  ];
+  runtimeBinPath = lib.makeBinPath [
+    coreutils
+    gnugrep
+    gzip
+  ];
+in
+stdenv.mkDerivation (finalAttrs: {
+  inherit pname version;
+
+  src = fetchurl {
+    url = "https://packages.microsoft.com/ubuntu/${ubuntuVersion}/prod/pool/main/m/mdatp/mdatp_${version}_${architecture}.deb";
+    hash = hashes.${system};
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    dpkg-deb --extract "$src" .
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/bin"
+    cp -a opt/microsoft/mdatp/sbin "$out/sbin"
+    cp -a opt/microsoft/mdatp/lib "$out/lib"
+    cp -a opt/microsoft/mdatp/conf "$out/conf"
+    cp -a opt/microsoft/mdatp/resources "$out/resources"
+    cp -a opt/microsoft/mdatp/definitions "$out/definitions"
+    cp -a opt/microsoft/mdatp/ml_model "$out/ml_model"
+    cp -a opt/microsoft/mdatp/tools "$out/tools"
+
+    for executable in "$out"/sbin/*; do
+      if [[ -f "$executable" && -x "$executable" && "$executable" != *.so ]]; then
+        patchelf --set-interpreter "$(cat "$NIX_CC/nix-support/dynamic-linker")" "$executable"
+        wrapProgram "$executable" \
+          --prefix LD_LIBRARY_PATH : "$out/lib:${runtimeLibraryPath}" \
+          --suffix PATH : "${runtimeBinPath}"
+      fi
+    done
+
+    ln -s "$out/sbin/wdavdaemonclient" "$out/bin/mdatp"
+    install -Dm444 opt/microsoft/mdatp/resources/mdatp_completion.bash \
+      "$out/share/bash-completion/completions/mdatp"
+    install -Dm444 opt/microsoft/mdatp/resources/mdatp_completion.zsh \
+      "$out/share/zsh/site-functions/_mdatp"
+
+    runHook postInstall
+  '';
+
+  # The vendor binaries require their bundled libraries and do not tolerate
+  # the generic ELF fixup pass. Their interpreters and runtime paths are set
+  # explicitly above instead.
+  dontPatchELF = true;
+
+  passthru = {
+    # nix-update cannot discover Microsoft repository indexes, move between
+    # Ubuntu repository versions, or update both architecture hashes together.
+    updateScript = ./update.sh;
+    tests.smoke = runCommand "${pname}-smoke" { nativeBuildInputs = [ gnugrep ]; } ''
+      ${finalAttrs.finalPackage}/bin/mdatp help >output 2>&1 || true
+      grep -Fq "Display all available options for this tool" output
+      touch "$out"
+    '';
+    tests.mdatp = nurTests.mdatp;
+  };
+
+  meta = {
+    description = "Microsoft Defender for Endpoint";
+    homepage = "https://www.microsoft.com/en-us/security/business/endpoint-security/microsoft-defender-endpoint";
+    changelog = "https://learn.microsoft.com/en-us/defender-endpoint/linux-whatsnew";
+    license = lib.licenses.unfree;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    platforms = builtins.attrNames architectures;
+    maintainers = with lib.maintainers; [ codgician ];
+    mainProgram = "mdatp";
+  };
+})

--- a/pkgs/mdatp/update.sh
+++ b/pkgs/mdatp/update.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl dpkg gnugrep gnused coreutils jq nix
+# shellcheck shell=bash
+
+set -euo pipefail
+
+nur="$(git rev-parse --show-toplevel)"
+path="$nur/pkgs/mdatp/default.nix"
+repository_root="https://packages.microsoft.com/ubuntu"
+package_path="prod/pool/main/m/mdatp"
+
+old_ubuntu_version=$(sed -nE 's/^[[:space:]]*ubuntuVersion = "([^"]+)";.*/\1/p' "$path")
+old_version=$(sed -nE 's/^[[:space:]]*version = "([^"]+)";.*/\1/p' "$path")
+old_amd64_hash=$(sed -nE 's/^[[:space:]]*x86_64-linux = "(sha256-[^"]+)";.*/\1/p' "$path")
+old_arm64_hash=$(sed -nE 's/^[[:space:]]*aarch64-linux = "(sha256-[^"]+)";.*/\1/p' "$path")
+
+# A release is stable only when its filename has no ring suffix and both
+# supported architectures are present. Inspect all Ubuntu repositories so the
+# package follows a release when Microsoft moves it to a newer Ubuntu version.
+mapfile -t ubuntu_versions < <(
+    curl -fsSL "$repository_root/" \
+        | sed -nE 's@.*href="([0-9]+\.[0-9]+)/".*@\1@p' \
+        | sort -Vr
+)
+
+new_ubuntu_version=""
+new_version=""
+
+for ubuntu_version in "${ubuntu_versions[@]}"; do
+    if ! package_index=$(curl -fsSL "$repository_root/$ubuntu_version/$package_path/" 2>/dev/null); then
+        continue
+    fi
+
+    while IFS= read -r candidate; do
+        if ! grep -Fq "href=\"mdatp_${candidate}_arm64.deb\"" <<<"$package_index"; then
+            continue
+        fi
+
+        if [[ -z "$new_version" ]] || dpkg --compare-versions "$candidate" gt "$new_version"; then
+            new_ubuntu_version="$ubuntu_version"
+            new_version="$candidate"
+        fi
+    done < <(
+        sed -nE 's@.*href="mdatp_([0-9]+(\.[0-9]+)*)_amd64\.deb".*@\1@p' <<<"$package_index"
+    )
+done
+
+if [[ -z "$new_ubuntu_version" || -z "$new_version" ]]; then
+    echo "Error: Could not resolve a stable, multi-architecture mdatp release" >&2
+    exit 1
+fi
+
+if [[ "$old_ubuntu_version" == "$new_ubuntu_version" && "$old_version" == "$new_version" ]]; then
+    echo "Current Ubuntu $old_ubuntu_version package $old_version is up-to-date"
+    exit 0
+fi
+
+amd64_url="$repository_root/$new_ubuntu_version/$package_path/mdatp_${new_version}_amd64.deb"
+arm64_url="$repository_root/$new_ubuntu_version/$package_path/mdatp_${new_version}_arm64.deb"
+new_amd64_hash=$(nix store prefetch-file --json "$amd64_url" | jq -er .hash)
+new_arm64_hash=$(nix store prefetch-file --json "$arm64_url" | jq -er .hash)
+
+echo "Updating mdatp: Ubuntu $old_ubuntu_version/$old_version -> Ubuntu $new_ubuntu_version/$new_version"
+
+sed -i \
+    -e "s|ubuntuVersion = \"$old_ubuntu_version\";|ubuntuVersion = \"$new_ubuntu_version\";|" \
+    -e "s|version = \"$old_version\";|version = \"$new_version\";|" \
+    -e "s|x86_64-linux = \"$old_amd64_hash\";|x86_64-linux = \"$new_amd64_hash\";|" \
+    -e "s|aarch64-linux = \"$old_arm64_hash\";|aarch64-linux = \"$new_arm64_hash\";|" \
+    "$path"
+
+echo "Updated mdatp to Ubuntu $new_ubuntu_version package $new_version"

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -38,6 +38,11 @@
 #
 # Each test then surfaces under flake `checks` and is built by CI.
 
-{ ... }:
+{ pkgs }:
 
-{ }
+let
+  nurPkgs = import ../pkgs { inherit pkgs; };
+in
+pkgs.lib.optionalAttrs (nurPkgs ? mdatp) {
+  mdatp = pkgs.callPackage ./mdatp.nix { inherit (nurPkgs) mdatp; };
+}

--- a/tests/mdatp.nix
+++ b/tests/mdatp.nix
@@ -1,0 +1,30 @@
+{
+  pkgs,
+  mdatp,
+}:
+
+pkgs.testers.runNixOSTest {
+  name = "mdatp";
+
+  nodes.machine = {
+    imports = [ ../modules/mdatp.nix ];
+
+    services.mdatp = {
+      enable = true;
+      package = mdatp;
+    };
+
+    virtualisation.memorySize = 4096;
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("mdatp.service")
+    machine.wait_for_unit("mde_netfilter_v2.socket")
+    machine.succeed("test $(readlink -f /opt/microsoft/mdatp) = ${mdatp}")
+    machine.succeed("systemctl is-active --quiet mdatp.service")
+    machine.wait_until_succeeds("mdatp version | grep -F ${mdatp.version}", timeout=120)
+    machine.wait_until_succeeds("test -s /var/opt/microsoft/mdatp/wdavstate", timeout=120)
+    machine.succeed("test $(systemctl show -P Result mde_netfilter_v2.service) = success")
+  '';
+}


### PR DESCRIPTION
## Summary

- package stable, ringless Microsoft Defender for Endpoint Debian artifacts for x86_64-linux and aarch64-linux
- add an Ubuntu-version-aware updater that refreshes both architecture hashes
- add an opt-in `services.mdatp` NixOS module with the Defender daemon, netfilter socket/service, runtime state directories, and runtime onboarding support
- add package smoke coverage and a NixOS VM integration test

## Verification

- `nix build path:.#mdatp.tests.smoke --no-link`
- `nix build path:.#legacyPackages.x86_64-linux.tests.mdatp --no-link`
- `nix fmt -- --ci modules pkgs/mdatp tests`
- updater reports Ubuntu 26.04 package 101.26052.0011 is current

The VM test confirms that `mdatp.service` stays active, `mdatp version` communicates with the daemon, Defender initializes its runtime state, and the netfilter service loads successfully.